### PR TITLE
Added support for a --match flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,16 @@ Proxy server can be used as regular NodeJS module
 
 ## Options
 
-You can change throttle speed and port number
+You can change throttle speed, port number, and URL matching string.
 
-    throttle-proxy --speed 50000 --port 9999
+    throttle-proxy --speed 50000 --port 9999 --match app.js
 
-Also you can use aliases `-s` and `-p` instead of full words.
+Also you can use aliases `-s`, `-p`, and `-m` instead of full words.
+
+Specifiying a URL matching string allows you to simulate latency for specific assets. The URL matching string is interpreted as a RegExp.
+
+### Defaults
+
+ * speed: 100000
+ * port: 3128
+ * match: false (match all request urls)

--- a/bin/throttle-proxy
+++ b/bin/throttle-proxy
@@ -9,7 +9,10 @@ var argv = require('optimist')
   .alias('speed', 's')
   .describe('port', 'incoming port number')
   .default('port', 3128)
-  .alias('port', 'p');
+  .alias('port', 'p')
+  .describe('match', 'throttle requests matching')
+  .default('match', false)
+  .alias('match', 'm');
 
 var config = argv.argv;
 
@@ -18,7 +21,7 @@ if (isNaN(parseInt(config.speed)) || isNaN(parseInt(config.port))) {
   process.exit(1);
 }
 
-proxy(config.speed).listen(config.port, function () {
-  console.log("Proxy server started on port %d and throttle speed to %d bytes per second",
-    config.port, config.speed);
+proxy(config.speed, config.match).listen(config.port, function () {
+  console.log("Proxy server started on port %d and throttle speed to %d bytes per second, matching %s",
+    config.port, config.speed, config.match || 'any request');
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,19 +7,25 @@ var url = require('url');
  * @param {http.IncomingMessage} request
  * @param {http.ServerResponse} response
  * @param {Throttle} throttle
+ * @param {String} match
  */
-function connectionHandler(request, response, throttle) {
+function connectionHandler(request, response, throttle, match) {
 
   var options = url.parse(request.url);
   options.method = request.method;
   options.headers = request.headers;
+  var throttleEnabled = !match || (new RegExp(match)).exec(request.url);
 
   var proxyRequest = http.request(options);
 
   proxyRequest.on('response', function (proxyResponse) {
     response.setHeader('via', 'throttle-proxy');
     response.writeHead(proxyResponse.statusCode, proxyResponse.headers);
-    proxyResponse.pipe(throttle).pipe(response);
+    if (throttleEnabled) {
+      proxyResponse.pipe(throttle).pipe(response);
+    } else {
+      proxyResponse.pipe(response);
+    }
   });
 
   proxyRequest.on('error', function (err) {
@@ -34,10 +40,11 @@ function connectionHandler(request, response, throttle) {
 /**
  * Server factory
  * @param {Number} speed
+ * @param {String} match
  * @type {Function}
  */
-module.exports = exports = function (speed) {
+module.exports = exports = function (speed, match) {
   return http.createServer(function (request, response) {
-    connectionHandler(request, response, new Throttle(speed));
+    connectionHandler(request, response, new Throttle(speed), match);
   });
 };


### PR DESCRIPTION
This commit adds support for a URL matching flag, --match. As there aren't existing tests, I didn't add my own, and I can only confirm anecdotally that this works in my informal testing and doesn't break existing behavior in those cases.
